### PR TITLE
Add coloured output to console messages.

### DIFF
--- a/tinytest.js
+++ b/tinytest.js
@@ -38,54 +38,54 @@
  * MIT License. See https://github.com/joewalnes/jstinytest/
  */
 var TinyTest = {
-
-    run: function(tests) {
-        var failures = 0;
-        for (var testName in tests) {
-            var testAction = tests[testName];
-            try {
-                testAction.apply(this);
-                console.log('Test:', testName, 'OK');
-            } catch (e) {
-                failures++;
-                console.error('Test:', testName, 'FAILED', e);
-                console.error(e.stack);
+    
+        run: function(tests) {
+            var failures = 0;
+            for (var testName in tests) {
+                var testAction = tests[testName];
+                try {
+                    testAction.apply(this);
+                    console.log('Test:' + testName + " %cOK ", "color: green");
+                } catch (e) {
+                    failures++;
+                    console.log('Test:' + testName + ' %cFAILED', 'color: red');
+                    console.error(e.stack);
+                }
             }
-        }
-        setTimeout(function() { // Give document a chance to complete
-            if (window.document && document.body) {
-                document.body.style.backgroundColor = (failures == 0 ? '#99ff99' : '#ff9999');
+            setTimeout(function() { // Give document a chance to complete
+                if (window.document && document.body) {
+                    document.body.style.backgroundColor = (failures == 0 ? '#99ff99' : '#ff9999');
+                }
+            }, 0);
+        },
+    
+        fail: function(msg) {
+            throw new Error('fail(): ' + msg);
+        },
+    
+        assert: function(value, msg) {
+            if (!value) {
+                throw new Error('assert(): ' + msg);
             }
-        }, 0);
-    },
-
-    fail: function(msg) {
-        throw new Error('fail(): ' + msg);
-    },
-
-    assert: function(value, msg) {
-        if (!value) {
-            throw new Error('assert(): ' + msg);
-        }
-    },
-
-    assertEquals: function(expected, actual) {
-        if (expected != actual) {
-            throw new Error('assertEquals() "' + expected + '" != "' + actual + '"');
-        }
-    },
-
-    assertStrictEquals: function(expected, actual) {
-        if (expected !== actual) {
-            throw new Error('assertStrictEquals() "' + expected + '" !== "' + actual + '"');
-        }
-    },
-
-};
-
-var fail               = TinyTest.fail.bind(TinyTest),
-    assert             = TinyTest.assert.bind(TinyTest),
-    assertEquals       = TinyTest.assertEquals.bind(TinyTest),
-    eq                 = TinyTest.assertEquals.bind(TinyTest), // alias for assertEquals
-    assertStrictEquals = TinyTest.assertStrictEquals.bind(TinyTest),
-    tests              = TinyTest.run.bind(TinyTest);
+        },
+    
+        assertEquals: function(expected, actual) {
+            if (expected != actual) {
+                throw new Error('assertEquals() "' + expected + '" != "' + actual + '"');
+            }
+        },
+    
+        assertStrictEquals: function(expected, actual) {
+            if (expected !== actual) {
+                throw new Error('assertStrictEquals() "' + expected + '" !== "' + actual + '"');
+            }
+        },
+    
+    };
+    
+    var fail               = TinyTest.fail.bind(TinyTest),
+        assert             = TinyTest.assert.bind(TinyTest),
+        assertEquals       = TinyTest.assertEquals.bind(TinyTest),
+        eq                 = TinyTest.assertEquals.bind(TinyTest), // alias for assertEquals
+        assertStrictEquals = TinyTest.assertStrictEquals.bind(TinyTest),
+        tests              = TinyTest.run.bind(TinyTest);


### PR DESCRIPTION
Sorry for the noisy diff (could be line endings...)
The only actual changes are on lines 48 and 51, taking advantage of the ability to style the `console.log` calls with CSS and replacing `console.error` with a styled `console.log` :)